### PR TITLE
Improved materials of universal-robots-ur5 VRML files

### DIFF
--- a/rlsg/universal-robots-ur5/link1.wrl
+++ b/rlsg/universal-robots-ur5/link1.wrl
@@ -12,11 +12,11 @@ DEF link1 Transform {
         Shape {
           appearance Appearance {
             material Material {
-              diffuseColor 0.752941 0.752941 0.752941
+              diffuseColor 0.4 0.4 0.4
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.1 0.1 0.1
+              ambientIntensity 1
+              shininess 0.1
             }
           }
           geometry IndexedFaceSet {
@@ -1046,13 +1046,14 @@ DEF link1 Transform {
       rotation -4.37114e-008 1 4.37114e-008 1.5708
       children [
         Shape {
+          # blue plastic
           appearance Appearance {
             material Material {
-              diffuseColor 0.501961 0.501961 1.000000
+              diffuseColor 0.33 0.69 0.84
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.33 0.69 0.84
+              ambientIntensity 1
+              shininess 0.3
             }
           }
           geometry IndexedFaceSet {

--- a/rlsg/universal-robots-ur5/link2.wrl
+++ b/rlsg/universal-robots-ur5/link2.wrl
@@ -12,11 +12,11 @@ DEF link2 Transform {
         Shape {
           appearance Appearance {
             material Material {
-              diffuseColor 0.752941 0.752941 0.752941
+              diffuseColor 0.4 0.4 0.4
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.1 0.1 0.1
+              ambientIntensity 1
+              shininess 0.1
             }
           }
           geometry IndexedFaceSet {
@@ -1046,6 +1046,7 @@ DEF link2 Transform {
       rotation -0.382863 0.840733 0.382863 1.74341
       children [
         Shape {
+          # metal
           appearance Appearance {
             material Material {
               diffuseColor 0.792157 0.819608 0.933333
@@ -1834,13 +1835,14 @@ DEF link2 Transform {
       rotation 0.57735 0.57735 -0.57735 4.18879
       children [
         Shape {
+          # blue plastic
           appearance Appearance {
             material Material {
-              diffuseColor 0.501961 0.501961 1.000000
+              diffuseColor 0.33 0.69 0.84
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.33 0.69 0.84
+              ambientIntensity 1
+              shininess 0.3
             }
           }
           geometry IndexedFaceSet {
@@ -2564,12 +2566,13 @@ DEF link2 Transform {
       children [
         Shape {
           appearance Appearance {
+            # dark grey paint
             material Material {
-              diffuseColor 0.752941 0.752941 0.752941
+              diffuseColor 0.4 0.4 0.4
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.1 0.1 0.1
+              ambientIntensity 1
+              shininess 0.1
             }
           }
           geometry IndexedFaceSet {
@@ -3599,13 +3602,14 @@ DEF link2 Transform {
       rotation 0.57735 0.57735 0.57735 2.0944
       children [
         Shape {
+          # blue
           appearance Appearance {
-            material Material {
-              diffuseColor 0.501961 0.501961 1.000000
+           material Material {
+              diffuseColor 0.33 0.69 0.84
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.33 0.69 0.84
+              ambientIntensity 1
+              shininess 0.3
             }
           }
           geometry IndexedFaceSet {

--- a/rlsg/universal-robots-ur5/link3.wrl
+++ b/rlsg/universal-robots-ur5/link3.wrl
@@ -12,11 +12,11 @@ DEF link3 Transform {
         Shape {
           appearance Appearance {
             material Material {
-              diffuseColor 0.752941 0.752941 0.752941
+              diffuseColor 0.4 0.4 0.4
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.1 0.1 0.1
+              ambientIntensity 1
+              shininess 0.1
             }
           }
           geometry IndexedFaceSet {
@@ -1440,13 +1440,14 @@ DEF link3 Transform {
       rotation -4.37114e-008 1 4.37114e-008 1.5708
       children [
         Shape {
+          # blue plastic
           appearance Appearance {
             material Material {
-              diffuseColor 0.501961 0.501961 1.000000
+              diffuseColor 0.33 0.69 0.84
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.33 0.69 0.84
+              ambientIntensity 1
+              shininess 0.3
             }
           }
           geometry IndexedFaceSet {
@@ -2108,11 +2109,11 @@ DEF link3 Transform {
         Shape {
           appearance Appearance {
             material Material {
-              diffuseColor 0.752941 0.752941 0.752941
+              diffuseColor 0.4 0.4 0.4
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.1 0.1 0.1
+              ambientIntensity 1
+              shininess 0.1
             }
           }
           geometry IndexedFaceSet {
@@ -2975,7 +2976,7 @@ DEF link3 Transform {
             material Material {
               diffuseColor 0.792157 0.819608 0.933333
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
+              specularColor 0.792157 0.819608 0.933333
               ambientIntensity 0.117647
               shininess 0.062500
             }

--- a/rlsg/universal-robots-ur5/link4.wrl
+++ b/rlsg/universal-robots-ur5/link4.wrl
@@ -10,13 +10,14 @@ DEF link4 Transform {
       rotation 0.57735 0.57735 -0.57735 4.18879
       children [
         Shape {
+          # blue plastic
           appearance Appearance {
             material Material {
-              diffuseColor 0.501961 0.501961 1.000000
+              diffuseColor 0.33 0.69 0.84
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.33 0.69 0.84
+              ambientIntensity 1
+              shininess 0.3
             }
           }
           geometry IndexedFaceSet {
@@ -678,11 +679,11 @@ DEF link4 Transform {
         Shape {
           appearance Appearance {
             material Material {
-              diffuseColor 0.752941 0.752941 0.752941
+              diffuseColor 0.4 0.4 0.4
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.1 0.1 0.1
+              ambientIntensity 1
+              shininess 0.1
             }
           }
           geometry IndexedFaceSet {

--- a/rlsg/universal-robots-ur5/link5.wrl
+++ b/rlsg/universal-robots-ur5/link5.wrl
@@ -10,13 +10,14 @@ DEF link5 Transform {
       rotation -4.37114e-008 1 4.37114e-008 1.5708
       children [
         Shape {
+          # blue plastic
           appearance Appearance {
             material Material {
-              diffuseColor 0.501961 0.501961 1.000000
+              diffuseColor 0.33 0.69 0.84
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.33 0.69 0.84
+              ambientIntensity 1
+              shininess 0.3
             }
           }
           geometry IndexedFaceSet {
@@ -678,11 +679,11 @@ DEF link5 Transform {
         Shape {
           appearance Appearance {
             material Material {
-              diffuseColor 0.752941 0.752941 0.752941
+              diffuseColor 0.4 0.4 0.4
               emissiveColor 0.000000 0.000000 0.000000
-              specularColor 0.752941 0.752941 0.752941
-              ambientIntensity 0.117647
-              shininess 0.062500
+              specularColor 0.1 0.1 0.1
+              ambientIntensity 1
+              shininess 0.1
             }
           }
           geometry IndexedFaceSet {


### PR DESCRIPTION
This pull request improves the colors of the UR5 VRML model to look more like the real thing (see image below)

![ur5](https://user-images.githubusercontent.com/4239304/108711737-1828f600-7516-11eb-9cdd-29b7a1c82d61.png)
